### PR TITLE
[Fix] Disable fragment masking in codegen

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -7,6 +7,9 @@ const config: CodegenConfig = {
   generates: {
     "./src/graphql/": {
       preset: "client",
+      presetConfig: {
+        fragmentMasking: false,
+      },
       plugins: [],
     },
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@rye-api/rye-sdk",
   "version": "1.0.0",
+  "description": "SDK for the Rye API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rye-com/rye-sdk"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Previously, fragment masking was enabled which made it harder to parse the types generated from the queries and mutations.

With fragment masking disabled, all types are inlined, making it easier to access data.