### PR TITLE
Remove cache exchange + add retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rye-api/rye-sdk",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
+        "@urql/exchange-retry": "^1.2.1",
         "urql": "^4.0.4"
       },
       "devDependencies": {
@@ -2927,6 +2928,15 @@
       "integrity": "sha512-DJ9q9+lcs5JL8DcU2J3NqsgeXYJva+1+Qt8HU94kzTPqVOIRRA7ouvy4ksUfPY+B5G2PQ+vLh+JJGyZCNXv0cg==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.1",
+        "wonka": "^6.3.2"
+      }
+    },
+    "node_modules/@urql/exchange-retry": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.2.1.tgz",
+      "integrity": "sha512-+BP73EJA0zJpGbdU1V6l2v8hb2m7/9dMHnF85ZjkaG6INkq4O7Tu9+jfC2wYxt2cajRxgxOoAL3iEJ5Xeerzyg==",
+      "dependencies": {
+        "@urql/core": ">=4.2.0",
         "wonka": "^6.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "@urql/exchange-retry": "^1.2.1",
     "urql": "^4.0.4"
   }
 }

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -1,6 +1,5 @@
 import {
   AnyVariables,
-  cacheExchange,
   Client,
   DocumentInput,
   fetchExchange,
@@ -187,7 +186,7 @@ class RyeClient implements IRyeClient {
     }
     return new Client({
       url: GRAPHQL_ENDPOINTS[this.environment],
-      exchanges: [cacheExchange, fetchExchange],
+      exchanges: [fetchExchange],
       fetchOptions: () => {
         return {
           headers: {

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -1,10 +1,11 @@
+import { retryExchange, type RetryExchangeOptions } from "@urql/exchange-retry";
 import {
-  AnyVariables,
+  type AnyVariables,
   Client,
-  DocumentInput,
+  type DocumentInput,
   fetchExchange,
-  OperationResult,
-  OperationResultSource,
+  type OperationResult,
+  type OperationResultSource,
 } from "urql";
 
 import {
@@ -184,9 +185,17 @@ class RyeClient implements IRyeClient {
         "RyeClient requires an authHeader and shopperIp to be set.",
       );
     }
+
+    const retryOptions: RetryExchangeOptions = {
+      initialDelayMs: 500,
+      maxNumberAttempts: 2,
+      // Retry on network errors
+      retryIf: (error) => error.networkError !== undefined,
+    }
+
     return new Client({
       url: GRAPHQL_ENDPOINTS[this.environment],
-      exchanges: [fetchExchange],
+      exchanges: [retryExchange(retryOptions), fetchExchange],
       fetchOptions: () => {
         return {
           headers: {


### PR DESCRIPTION
## Changes

1. Remove `cacheExchange`. It causes problems when polling as repeated calls to e.g. `checkoutByCartId` will hit the in-memory cache unless a mutation has invalidated the cache entry.
2. Retry operations one time if they failed due to a network error. The options passed to the retry exchange are ~the defaults, except the initial delay is cut down a bit to make the retry occur slightly faster.