### PR TITLE
Select `orderId` on `ShopifyStore`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@urql/exchange-retry": "^1.2.1",
-        "urql": "^4.0.4"
+        "@urql/core": "^4.3.0",
+        "@urql/exchange-retry": "^1.2.1"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^4.0.1",
@@ -30,9 +30,10 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
-      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.7.tgz",
+      "integrity": "sha512-E3Qku4mTzdrlwVWGPxklDnME5ANrEGetvYw4i2GCRlppWXXE4QD66j7pwb8HelZwS6LnqEChhrSOGCXpbiu6MQ==",
+      "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -3595,9 +3596,10 @@
       "dev": true
     },
     "node_modules/@urql/core": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.2.3.tgz",
-      "integrity": "sha512-DJ9q9+lcs5JL8DcU2J3NqsgeXYJva+1+Qt8HU94kzTPqVOIRRA7ouvy4ksUfPY+B5G2PQ+vLh+JJGyZCNXv0cg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.3.0.tgz",
+      "integrity": "sha512-wT+FeL8DG4x5o6RfHEnONNFVDM3616ouzATMYUClB6CB+iIu2mwfBKd7xSUxYOZmwtxna5/hDRQdMl3nbQZlnw==",
+      "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.1",
         "wonka": "^6.3.2"
@@ -6704,7 +6706,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6985,6 +6988,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7849,18 +7853,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react-is": {
       "version": "18.2.0",
@@ -8989,18 +8981,6 @@
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
       "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
       "dev": true
-    },
-    "node_modules/urql": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/urql/-/urql-4.0.6.tgz",
-      "integrity": "sha512-meXJ2puOd64uCGKh7Fse2R7gPa8+ZpBOoA62jN7CPXXUt7SVZSdeXWSpB3HvlfzLUkEqsWbvshwrgeWRYNNGaQ==",
-      "dependencies": {
-        "@urql/core": "^4.2.0",
-        "wonka": "^6.3.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0"
-      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vitest": "^1.4.0"
   },
   "dependencies": {
-    "@urql/exchange-retry": "^1.2.1",
-    "urql": "^4.0.4"
+    "@urql/core": "^4.3.0",
+    "@urql/exchange-retry": "^1.2.1"
   }
 }

--- a/src/gql/fragments.ts
+++ b/src/gql/fragments.ts
@@ -172,6 +172,7 @@ export const Cart = graphql(`
       stores {
         ... on AmazonStore {
           isSubmitted
+          orderId
           requestId
           errors {
             code
@@ -189,6 +190,9 @@ export const Cart = graphql(`
           }
         }
         ... on ShopifyStore {
+          isSubmitted
+          orderId
+          requestId
           errors {
             code
             message

--- a/src/gql/submitCart.ts
+++ b/src/gql/submitCart.ts
@@ -7,6 +7,7 @@ export const SUBMIT_CART_MUTATION = graphql(`
         id
         stores {
           status
+          orderId
           requestId
           store {
             ... on AmazonStore {

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -1,4 +1,3 @@
-import { retryExchange, type RetryExchangeOptions } from '@urql/exchange-retry';
 import {
   type AnyVariables,
   Client,
@@ -6,7 +5,8 @@ import {
   fetchExchange,
   type OperationResult,
   type OperationResultSource,
-} from 'urql';
+} from '@urql/core';
+import { retryExchange, type RetryExchangeOptions } from '@urql/exchange-retry';
 
 import {
   DEFAULT_ENVIRONMENT,


### PR DESCRIPTION
We were previously only selecting `requestId` for `AmazonStore`, which meant developers could not retrieve `ShopifyStore.requestId` at the time of cart creation. We _were_ correctly selecting this field after cart submission.

I've started selecting `orderId` as well, because `requestId` is deprecated.

Also quickly getting RYE-4289 out of the way while I'm here.