### PR TITLE
Improve debuggability of the SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rye-api/rye-sdk",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@urql/core": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "SDK for the Rye API",
   "repository": {
     "type": "git",

--- a/src/gql/requestStoreByURL.ts
+++ b/src/gql/requestStoreByURL.ts
@@ -3,6 +3,7 @@ import { graphql } from '../graphql';
 export const REQUEST_STORE_BY_URL_MUTATION = graphql(`
   mutation RequestStoreByURL($input: RequestStoreByURLInput!) {
     requestStoreByURL(input: $input) {
+      canonicalDomain
       requestID
     }
   }

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -215,6 +215,7 @@ class RyeClient implements IRyeClient {
           headers: {
             Authorization: this.authHeader!,
             [RYE_SHOPPER_IP]: this.shopperIp!,
+            'rye-debug': 'true',
             'rye-user-agent': `Rye/v1 Node/${RYE_SDK_VERSION}`,
           },
         };

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -197,6 +197,11 @@ class RyeClient implements IRyeClient {
     if (!this.authHeader || !this.shopperIp) {
       throw new Error('RyeClient requires an authHeader and shopperIp to be set.');
     }
+    if (typeof fetch !== 'function') {
+      throw new Error(
+        'RyeClient requires a global fetch function to be available. Try setting up `node-fetch`: https://www.npmjs.com/package/node-fetch#providing-global-access',
+      );
+    }
 
     warnIfAuthHeaderInvalid(this.authHeader);
 
@@ -235,6 +240,10 @@ class RyeClient implements IRyeClient {
     variables: TVariables,
     method: OPERATION = OPERATION.QUERY,
   ): Promise<OperationResultSource<OperationResult<TResult, TVariables>>> {
+    if (typeof fetch !== 'function') {
+      //
+    }
+
     const tryRequest = async () => {
       return await this.ryeClient[method](query, variables);
     };

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -240,10 +240,6 @@ class RyeClient implements IRyeClient {
     variables: TVariables,
     method: OPERATION = OPERATION.QUERY,
   ): Promise<OperationResultSource<OperationResult<TResult, TVariables>>> {
-    if (typeof fetch !== 'function') {
-      //
-    }
-
     const tryRequest = async () => {
       return await this.ryeClient[method](query, variables);
     };


### PR DESCRIPTION
Two changes to make debugging errors / issues raised by devs easier:

1. Set `rye-debug: true` so that the API returns a trace ID for all operations executed by Rye SDK.
2. Loudly fail when global `fetch` is not available (we've had 2x developers run into this issue now)

We also now select `canonicalDomain` from `requestStoreByURL` so that developers can map storefront domains -> canonical domains correctly using Rye SDK. [This](https://docs.rye.com/libraries/rye-sdk/mutations/request-store-by-url) docs page will need updating to reflect this.