### PR TITLE
Load `Cart.cost`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rye-api/rye-sdk",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@urql/core": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "SDK for the Rye API",
   "repository": {
     "type": "git",

--- a/src/gql/fragments.ts
+++ b/src/gql/fragments.ts
@@ -164,11 +164,37 @@ export const ShopifyCartLines = graphql(`
   }
 `);
 
+export const Price = graphql(`
+  fragment Price on Price {
+    currency
+    displayValue
+    value
+  }
+`);
+
 export const Cart = graphql(`
   fragment Cart on CartResponse {
     cart {
       id
       ...BuyerIdentity @include(if: $fetchBuyerIdentity)
+      cost {
+        isEstimated
+        margin {
+          ...Price
+        }
+        shipping {
+          ...Price
+        }
+        subtotal {
+          ...Price
+        }
+        tax {
+          ...Price
+        }
+        total {
+          ...Price
+        }
+      }
       stores {
         ... on AmazonStore {
           isSubmitted


### PR DESCRIPTION
The `Cart.cost` field was previously unavailable when using Rye SDK.