### PR TITLE
Export friendlier types from Rye SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# System files
+.DS_Store
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -99,10 +99,6 @@ const result = await ryeClient.createCart({
       ],
     },
   },
-  fetchBuyerIdentity: false, // Set to true to fetch buyer identity
-  fetchOffer: false, // Set to true to fetch offers for each store
-  fetchCartLines: false, // Set to true to fetch cart lines
-  fetchShippingMethods: false, // Set to true to fetch shipping methods
 });
 ```
 
@@ -178,9 +174,6 @@ const result = await ryeClient.updateCartBuyerIdentity({
       postalCode: '<POSTAL_CODE>',
     },
   },
-  fetchOffer: false, // Set to true to fetch offers for each store
-  fetchCartLines: false, // Set to true to fetch cart lines
-  fetchShippingMethods: false, // Set to true to fetch shipping methods
 });
 ```
 
@@ -197,10 +190,6 @@ const result = await ryeClient.updateCartSelectedShippingOptions({
       },
     ],
   },
-  fetchBuyerIdentity: false, // Set to true to fetch buyer identity
-  fetchOffer: false, // Set to true to fetch offers for each store
-  fetchCartLines: false, // Set to true to fetch cart lines
-  fetchShippingMethods: false, // Set to true to fetch shipping methods
 });
 ```
 
@@ -266,10 +255,6 @@ const result = await ryeClient.getProductsByDomainV2({
 ```ts
 const result = await ryeClient.getCart({
   id: '<CART_ID>',
-  fetchBuyerIdentity: false, // Set to true to fetch buyer identity
-  fetchOffer: false, // Set to true to fetch offers for each store
-  fetchCartLines: false, // Set to true to fetch cart lines
-  fetchShippingMethods: false, // Set to true to fetch shipping methods
 });
 ```
 
@@ -286,10 +271,6 @@ const result = await ryeClient.orderById({
 ```ts
 const result = await ryeClient.checkoutByCartId({
   id: '<CART_ID>',
-  fetchBuyerIdentity: false, // Set to true to fetch buyer identity
-  fetchOffer: false, // Set to true to fetch offers for each store
-  fetchCartLines: false, // Set to true to fetch cart lines
-  fetchShippingMethods: false, // Set to true to fetch shipping methods
 });
 ```
 

--- a/codegen.ts
+++ b/codegen.ts
@@ -11,7 +11,6 @@ const config: CodegenConfig = {
       config: {
         dedupeFragments: false,
         defaultScalarType: 'unknown',
-        enumsAsConst: true,
         scalars: {
           Percentage: 'number',
           Time: 'string',

--- a/codegen.ts
+++ b/codegen.ts
@@ -7,11 +7,23 @@ const config: CodegenConfig = {
   generates: {
     './src/graphql/': {
       preset: 'client',
-      presetConfig: {
-        fragmentMasking: false,
+      presetConfig: { fragmentMasking: false },
+      config: {
+        dedupeFragments: false,
+        defaultScalarType: 'unknown',
+        enumsAsConst: true,
+        scalars: {
+          Percentage: 'number',
+          Time: 'string',
+          URL: 'string',
+        },
+        strictScalars: true,
+        useTypeImports: true,
       },
-      plugins: [],
     },
+  },
+  hooks: {
+    afterOneFileWrite: ['prettier --write'],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rye-api/rye-sdk",
-      "version": "1.4.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@urql/core": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rye-api/rye-sdk",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "SDK for the Rye API",
   "repository": {
     "type": "git",

--- a/src/gql/addCartItems.ts
+++ b/src/gql/addCartItems.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const ADD_CART_ITEMS_MUTATION = graphql(`
-  mutation AddCartItems(
-    $input: CartItemsAddInput!
-    $fetchBuyerIdentity: Boolean = false
-    $fetchShippingMethods: Boolean = false
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = true
-  ) {
+  mutation AddCartItems($input: CartItemsAddInput!) {
     addCartItems(input: $input) {
       ...Cart
     }

--- a/src/gql/checkoutByCartId.ts
+++ b/src/gql/checkoutByCartId.ts
@@ -40,7 +40,9 @@ export const CHECKOUT_BY_CART_ID_QUERY = graphql(`
             isShippingRequired
             ...AmazonOffer
             offer {
-              ...AmazonShippingMethods
+              shippingMethods {
+                ...ShippingMethod
+              }
             }
           }
           ... on ShopifyStore {
@@ -55,7 +57,9 @@ export const CHECKOUT_BY_CART_ID_QUERY = graphql(`
             ...ShopifyCartLines
             ...ShopifyOffer
             offer {
-              ...ShopifyShippingMethods
+              shippingMethods {
+                ...ShippingMethod
+              }
             }
           }
         }

--- a/src/gql/checkoutByCartId.ts
+++ b/src/gql/checkoutByCartId.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const CHECKOUT_BY_CART_ID_QUERY = graphql(`
-  query CheckoutByCartID(
-    $cartID: ID!
-    $fetchBuyerIdentity: Boolean = true
-    $fetchShippingMethods: Boolean = true
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = true
-  ) {
+  query CheckoutByCartID($cartID: ID!) {
     checkoutByCartID(cartID: $cartID) {
       status
       orders {
@@ -29,7 +23,7 @@ export const CHECKOUT_BY_CART_ID_QUERY = graphql(`
       }
       cart {
         id
-        ...BuyerIdentity @include(if: $fetchBuyerIdentity)
+        ...BuyerIdentity
         stores {
           ... on AmazonStore {
             isSubmitted
@@ -42,11 +36,11 @@ export const CHECKOUT_BY_CART_ID_QUERY = graphql(`
               }
             }
             store
-            ...AmazonCartLines @include(if: $fetchCartLines)
+            ...AmazonCartLines
             isShippingRequired
-            ...AmazonOffer @include(if: $fetchOffer)
+            ...AmazonOffer
             offer {
-              ...AmazonShippingMethods @include(if: $fetchShippingMethods)
+              ...AmazonShippingMethods
             }
           }
           ... on ShopifyStore {
@@ -58,10 +52,10 @@ export const CHECKOUT_BY_CART_ID_QUERY = graphql(`
               }
             }
             store
-            ...ShopifyCartLines @include(if: $fetchCartLines)
-            ...ShopifyOffer @include(if: $fetchOffer)
+            ...ShopifyCartLines
+            ...ShopifyOffer
             offer {
-              ...ShopifyShippingMethods @include(if: $fetchShippingMethods)
+              ...ShopifyShippingMethods
             }
           }
         }

--- a/src/gql/createCart.ts
+++ b/src/gql/createCart.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const CREATE_CART_MUTATION = graphql(`
-  mutation CreateCart(
-    $input: CartCreateInput!
-    $fetchBuyerIdentity: Boolean = false
-    $fetchShippingMethods: Boolean = false
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = true
-  ) {
+  mutation CreateCart($input: CartCreateInput!) {
     createCart(input: $input) {
       ...Cart
     }

--- a/src/gql/deleteCartItems.ts
+++ b/src/gql/deleteCartItems.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const DELETE_CART_ITEMS_MUTATION = graphql(`
-  mutation DeleteCartItems(
-    $input: CartItemsDeleteInput!
-    $fetchBuyerIdentity: Boolean = false
-    $fetchShippingMethods: Boolean = false
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = true
-  ) {
+  mutation DeleteCartItems($input: CartItemsDeleteInput!) {
     deleteCartItems(input: $input) {
       ...Cart
     }

--- a/src/gql/fragments.ts
+++ b/src/gql/fragments.ts
@@ -251,11 +251,6 @@ export const ProductDetails = graphql(`
       currency
       displayValue
     }
-  }
-`);
-
-export const AdditionalProductDetails = graphql(`
-  fragment AdditionalProductDetails on Product {
     ... on AmazonProduct {
       ASIN
       titleExcludingVariantName

--- a/src/gql/fragments.ts
+++ b/src/gql/fragments.ts
@@ -17,50 +17,24 @@ export const BuyerIdentity = graphql(`
   }
 `);
 
-export const AmazonShippingMethods = graphql(`
-  fragment AmazonShippingMethods on AmazonOffer {
-    shippingMethods {
-      id
-      label
-      price {
-        value
-        displayValue
-        currency
-      }
-      taxes {
-        value
-        displayValue
-        currency
-      }
-      total {
-        value
-        displayValue
-        currency
-      }
+export const ShippingMethod = graphql(`
+  fragment ShippingMethod on ShippingMethod {
+    id
+    label
+    price {
+      value
+      displayValue
+      currency
     }
-  }
-`);
-
-export const ShopifyShippingMethods = graphql(`
-  fragment ShopifyShippingMethods on ShopifyOffer {
-    shippingMethods {
-      id
-      label
-      price {
-        value
-        displayValue
-        currency
-      }
-      taxes {
-        value
-        displayValue
-        currency
-      }
-      total {
-        value
-        displayValue
-        currency
-      }
+    taxes {
+      value
+      displayValue
+      currency
+    }
+    total {
+      value
+      displayValue
+      currency
     }
   }
 `);
@@ -88,7 +62,9 @@ export const AmazonOffer = graphql(`
         currency
       }
       notAvailableIds
-      ...AmazonShippingMethods
+      shippingMethods {
+        ...ShippingMethod
+      }
     }
   }
 `);
@@ -116,7 +92,9 @@ export const ShopifyOffer = graphql(`
         currency
       }
       notAvailableIds
-      ...ShopifyShippingMethods
+      shippingMethods {
+        ...ShippingMethod
+      }
     }
   }
 `);
@@ -176,6 +154,10 @@ export const Cart = graphql(`
   fragment Cart on CartResponse {
     cart {
       id
+      attributes {
+        key
+        value
+      }
       ...BuyerIdentity
       cost {
         isEstimated
@@ -205,6 +187,11 @@ export const Cart = graphql(`
             message
             details {
               productIds
+              reasons {
+                code
+                productId
+                reason
+              }
             }
           }
           store
@@ -212,7 +199,9 @@ export const Cart = graphql(`
           isShippingRequired
           ...AmazonOffer
           offer {
-            ...AmazonShippingMethods
+            shippingMethods {
+              ...ShippingMethod
+            }
           }
         }
         ... on ShopifyStore {
@@ -230,7 +219,9 @@ export const Cart = graphql(`
           ...ShopifyCartLines
           ...ShopifyOffer
           offer {
-            ...ShopifyShippingMethods
+            shippingMethods {
+              ...ShippingMethod
+            }
           }
         }
       }

--- a/src/gql/fragments.ts
+++ b/src/gql/fragments.ts
@@ -176,7 +176,7 @@ export const Cart = graphql(`
   fragment Cart on CartResponse {
     cart {
       id
-      ...BuyerIdentity @include(if: $fetchBuyerIdentity)
+      ...BuyerIdentity
       cost {
         isEstimated
         margin {
@@ -208,11 +208,11 @@ export const Cart = graphql(`
             }
           }
           store
-          ...AmazonCartLines @include(if: $fetchCartLines)
+          ...AmazonCartLines
           isShippingRequired
-          ...AmazonOffer @include(if: $fetchOffer)
+          ...AmazonOffer
           offer {
-            ...AmazonShippingMethods @include(if: $fetchShippingMethods)
+            ...AmazonShippingMethods
           }
         }
         ... on ShopifyStore {
@@ -227,10 +227,10 @@ export const Cart = graphql(`
             }
           }
           store
-          ...ShopifyCartLines @include(if: $fetchCartLines)
-          ...ShopifyOffer @include(if: $fetchOffer)
+          ...ShopifyCartLines
+          ...ShopifyOffer
           offer {
-            ...ShopifyShippingMethods @include(if: $fetchShippingMethods)
+            ...ShopifyShippingMethods
           }
         }
       }

--- a/src/gql/fragments.ts
+++ b/src/gql/fragments.ts
@@ -251,6 +251,31 @@ export const ProductDetails = graphql(`
       currency
       displayValue
     }
+    variants {
+      id
+      image {
+        url
+      }
+      title
+
+      ... on AmazonVariant {
+        dimensions {
+          name
+          value
+        }
+        url
+      }
+      ... on ShopifyVariant {
+        isAvailable
+        isShippingRequired
+        name
+        priceV2 {
+          ...Price
+        }
+        quantityAvailable
+      }
+    }
+
     ... on AmazonProduct {
       ASIN
       titleExcludingVariantName

--- a/src/gql/getCart.ts
+++ b/src/gql/getCart.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const GET_CART_QUERY = graphql(`
-  query GetCart(
-    $id: ID!
-    $fetchBuyerIdentity: Boolean = true
-    $fetchShippingMethods: Boolean = true
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = true
-  ) {
+  query GetCart($id: ID!) {
     getCart(id: $id) {
       ...Cart
     }

--- a/src/gql/productById.ts
+++ b/src/gql/productById.ts
@@ -4,7 +4,6 @@ export const PRODUCT_BY_ID_QUERY = graphql(`
   query ProductByID($input: ProductByIDInput!) {
     productByID(input: $input) {
       ...ProductDetails
-      ...AdditionalProductDetails
     }
   }
 `);

--- a/src/gql/productById.ts
+++ b/src/gql/productById.ts
@@ -1,10 +1,10 @@
 import { graphql } from '../graphql';
 
 export const PRODUCT_BY_ID_QUERY = graphql(`
-  query ProductByID($input: ProductByIDInput!, $includeAdditionalProductDetails: Boolean = false) {
+  query ProductByID($input: ProductByIDInput!) {
     productByID(input: $input) {
       ...ProductDetails
-      ...AdditionalProductDetails @include(if: $includeAdditionalProductDetails)
+      ...AdditionalProductDetails
     }
   }
 `);

--- a/src/gql/productsByDomainV2.ts
+++ b/src/gql/productsByDomainV2.ts
@@ -1,14 +1,10 @@
 import { graphql } from '../graphql';
 
 export const PRODUCTS_BY_DOMAIN_V2_QUERY = graphql(`
-  query ProductsByDomainV2(
-    $input: productsByDomainInput!
-    $pagination: OffsetPaginationInput!
-    $includeAdditionalProductDetails: Boolean = false
-  ) {
+  query ProductsByDomainV2($input: productsByDomainInput!, $pagination: OffsetPaginationInput!) {
     productsByDomainV2(input: $input, pagination: $pagination) {
       ...ProductDetails
-      ...AdditionalProductDetails @include(if: $includeAdditionalProductDetails)
+      ...AdditionalProductDetails
     }
   }
 `);

--- a/src/gql/productsByDomainV2.ts
+++ b/src/gql/productsByDomainV2.ts
@@ -4,7 +4,6 @@ export const PRODUCTS_BY_DOMAIN_V2_QUERY = graphql(`
   query ProductsByDomainV2($input: productsByDomainInput!, $pagination: OffsetPaginationInput!) {
     productsByDomainV2(input: $input, pagination: $pagination) {
       ...ProductDetails
-      ...AdditionalProductDetails
     }
   }
 `);

--- a/src/gql/updateCartBuyerIdentity.ts
+++ b/src/gql/updateCartBuyerIdentity.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const UPDATE_CART_BUYER_IDENTITY_MUTATION = graphql(`
-  mutation UpdateCartBuyerIdentity(
-    $input: CartBuyerIdentityUpdateInput!
-    $fetchBuyerIdentity: Boolean = false
-    $fetchShippingMethods: Boolean = true
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = false
-  ) {
+  mutation UpdateCartBuyerIdentity($input: CartBuyerIdentityUpdateInput!) {
     updateCartBuyerIdentity(input: $input) {
       ...Cart
     }

--- a/src/gql/updateCartItems.ts
+++ b/src/gql/updateCartItems.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const UPDATE_CART_ITEMS_MUTATION = graphql(`
-  mutation UpdateCartItems(
-    $input: CartItemsUpdateInput!
-    $fetchBuyerIdentity: Boolean = false
-    $fetchShippingMethods: Boolean = false
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = true
-  ) {
+  mutation UpdateCartItems($input: CartItemsUpdateInput!) {
     updateCartItems(input: $input) {
       ...Cart
     }

--- a/src/gql/updateCartSelectedShippingOptions.ts
+++ b/src/gql/updateCartSelectedShippingOptions.ts
@@ -1,13 +1,7 @@
 import { graphql } from '../graphql';
 
 export const UPDATE_CART_SELECTED_SHIPPING_OPTIONS_MUTATION = graphql(`
-  mutation UpdateCartSelectedShippingOptions(
-    $input: UpdateCartSelectedShippingOptionsInput!
-    $fetchBuyerIdentity: Boolean = false
-    $fetchShippingMethods: Boolean = true
-    $fetchOffer: Boolean = true
-    $fetchCartLines: Boolean = false
-  ) {
+  mutation UpdateCartSelectedShippingOptions($input: UpdateCartSelectedShippingOptionsInput!) {
     updateCartSelectedShippingOptions(input: $input) {
       ...Cart
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 export * from './constants';
-export * from './graphql/gql';
 export * from './graphql/graphql';
-export * from './graphql/index';
 export * from './ryeClient';
 export * from './types';

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -52,6 +52,7 @@ import {
   RequestStoreByUrlMutation,
   ShopifyAppQuery,
   ShopifyCollectionQuery,
+  ShopifyProduct,
   SubmitCartMutation,
   UpdateCartBuyerIdentityMutation,
   UpdateCartItemsMutation,
@@ -446,3 +447,16 @@ export class RyeClient {
     return response.data?.shopifyCollection;
   };
 }
+
+const client = new RyeClient();
+
+const product = await client.getProductById({
+  input: { id: '123231', marketplace: Marketplace.Shopify },
+});
+if (product?.__typename === 'ShopifyProduct') {
+  doSomethingWithAProduct(product);
+}
+
+async function doSomethingWithAProduct(
+  _product: Extract<ProductByIdQuery['productByID'], { __typename?: 'ShopifyProduct' }>,
+) {}

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -447,16 +447,3 @@ export class RyeClient {
     return response.data?.shopifyCollection;
   };
 }
-
-const client = new RyeClient();
-
-const product = await client.getProductById({
-  input: { id: '123231', marketplace: Marketplace.Shopify },
-});
-if (product?.__typename === 'ShopifyProduct') {
-  doSomethingWithAProduct(product);
-}
-
-async function doSomethingWithAProduct(
-  _product: Extract<ProductByIdQuery['productByID'], { __typename?: 'ShopifyProduct' }>,
-) {}

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -43,6 +43,7 @@ import {
   EnvironmentTokenQuery,
   GetCartQuery,
   IntegratedShopifyStoreQuery,
+  Marketplace,
   OrderByIdQuery,
   ProductByIdQuery,
   ProductsByDomainV2Query,
@@ -91,26 +92,10 @@ export class RyeClient {
   private environment: ENVIRONMENT;
   private ryeClient: Client;
 
-  /**
-   * @deprecated This signature is deprecated. Please use the alternate constructor signature that takes a {@link RyeClientOptions} bag.
-   */
-  constructor(authHeader: string, shopperIp: string, environment?: ENVIRONMENT);
-  constructor(options: RyeClientOptions);
-  constructor(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...args: any[]
-  ) {
-    if (args.length === 1) {
-      const options = args[0];
-      this.authHeader = options.authHeader;
-      this.shopperIp = options.shopperIp;
-      this.environment = options.environment || DEFAULT_ENVIRONMENT;
-    } else {
-      const [authHeader, shopperIp, environment] = args;
-      this.authHeader = authHeader;
-      this.shopperIp = shopperIp;
-      this.environment = environment || DEFAULT_ENVIRONMENT;
-    }
+  constructor(options: RyeClientOptions) {
+    this.authHeader = options.authHeader;
+    this.shopperIp = options.shopperIp;
+    this.environment = options.environment || DEFAULT_ENVIRONMENT;
 
     this.ryeClient = this.initializeClient();
   }

--- a/src/ryeClient.ts
+++ b/src/ryeClient.ts
@@ -78,88 +78,14 @@ import type {
 } from './types';
 import { warnIfAuthHeaderInvalid } from './utils';
 
-interface IRyeClient {
-  getCart(getCartParams: GetCartParams): Promise<GetCartQuery['getCart'] | undefined>;
-
-  createCart(
-    createCartParams: CreateCartParams,
-  ): Promise<CreateCartMutation['createCart'] | undefined>;
-
-  addCartItems(
-    addCartItemsParams: AddCartItemsParams,
-  ): Promise<AddCartItemsMutation['addCartItems'] | undefined>;
-
-  deleteCartItems(
-    deleteCartItemsParams: DeleteCartItemsParams,
-  ): Promise<DeleteCartItemsMutation['deleteCartItems'] | undefined>;
-
-  updateCartItems(
-    updateCartItemsParams: UpdateCartItemsParams,
-  ): Promise<UpdateCartItemsMutation['updateCartItems'] | undefined>;
-
-  removeCart(
-    removeCartItemsParams: RemoveCartParams,
-  ): Promise<RemoveCartMutation['removeCart'] | undefined>;
-
-  updateCartBuyerIdentity(
-    updateCartBuyerIdentityParams: UpdateCartBuyerIdentityParams,
-  ): Promise<UpdateCartBuyerIdentityMutation['updateCartBuyerIdentity'] | undefined>;
-
-  updateCartSelectedShippingOptions(
-    updateCartSelectedShippingOptionsParams: UpdateCartSelectedShippingOptionsParams,
-  ): Promise<
-    UpdateCartSelectedShippingOptionsMutation['updateCartSelectedShippingOptions'] | undefined
-  >;
-
-  submitCart(
-    submitCartParams: SubmitCartParams,
-  ): Promise<SubmitCartMutation['submitCart'] | undefined>;
-
-  orderById(orderByIdParams: OrderByIdParams): Promise<OrderByIdQuery['orderByID'] | undefined>;
-
-  checkoutByCartId(
-    checkoutByCartIdParams: CheckoutByCartIdParams,
-  ): Promise<CheckoutByCartIdQuery['checkoutByCartID'] | undefined>;
-
-  getEnvironmentToken(): Promise<EnvironmentTokenQuery['environmentToken'] | undefined>;
-
-  getShopifyAppInformation(
-    shopifyAppParams: ShopifyAppParams,
-  ): Promise<ShopifyAppQuery['shopifyApp'] | undefined>;
-
-  requestProductByUrl(
-    requestProductByUrlParams: RequestProductByUrlParams,
-  ): Promise<RequestProductByUrlMutation['requestProductByURL'] | undefined>;
-
-  requestStoreByUrl(
-    requestStoreByUrlParams: RequestStoreByUrlParams,
-  ): Promise<RequestStoreByUrlMutation['requestStoreByURL'] | undefined>;
-
-  getProductById(
-    productByIdParams: ProductByIdParams,
-  ): Promise<ProductByIdQuery['productByID'] | undefined>;
-
-  getProductsByDomainV2(
-    productsByDomainV2Params: ProductsByDomainV2Params,
-  ): Promise<ProductsByDomainV2Query['productsByDomainV2'] | undefined>;
-
-  getIntegratedShopifyStore(
-    integratedShopifyStoreParams: IntegratedShopifyStoreParams,
-  ): Promise<IntegratedShopifyStoreQuery['integratedShopifyStore'] | undefined>;
-
-  getShopifyCollection(
-    shopifyCollectionParams: ShopifyCollectionParams,
-  ): Promise<ShopifyCollectionQuery['shopifyCollection'] | undefined>;
-}
-
-interface RyeClientOptions {
+export interface RyeClientOptions {
   authHeader: string;
   /** @default {ENVIRONMENT.PRODUCTION} */
   environment?: ENVIRONMENT;
   shopperIp: string;
 }
 
-class RyeClient implements IRyeClient {
+export class RyeClient {
   private authHeader: string | null;
   private shopperIp: string | null;
   private environment: ENVIRONMENT;
@@ -535,5 +461,3 @@ class RyeClient implements IRyeClient {
     return response.data?.shopifyCollection;
   };
 }
-
-export { RyeClient };

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,42 +16,22 @@ import {
 
 export type GetCartParams = {
   id: string;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type CreateCartParams = {
   input: CartCreateInput;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type AddCartItemsParams = {
   input: CartItemsAddInput;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type DeleteCartItemsParams = {
   input: CartItemsDeleteInput;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type UpdateCartItemsParams = {
   input: CartItemsUpdateInput;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type RemoveCartParams = {
@@ -60,18 +40,10 @@ export type RemoveCartParams = {
 
 export type UpdateCartBuyerIdentityParams = {
   input: CartBuyerIdentityUpdateInput;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type UpdateCartSelectedShippingOptionsParams = {
   input: UpdateCartSelectedShippingOptionsInput;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type SubmitCartParams = {
@@ -84,10 +56,6 @@ export type OrderByIdParams = {
 
 export type CheckoutByCartIdParams = {
   cartID: string;
-  fetchBuyerIdentity?: boolean;
-  fetchShippingMethods?: boolean;
-  fetchOffer?: boolean;
-  fetchCartLines?: boolean;
 };
 
 export type ShopifyAppParams = {
@@ -104,13 +72,11 @@ export type RequestStoreByUrlParams = {
 
 export type ProductByIdParams = {
   input: ProductByIdInput;
-  includeAdditionalProductDetails: boolean;
 };
 
 export type ProductsByDomainV2Params = {
   input: ProductsByDomainInput;
   pagination: OffsetPaginationInput;
-  includeAdditionalProductDetails: boolean;
 };
 
 export type IntegratedShopifyStoreParams = {


### PR DESCRIPTION
Updates Rye SDK codegen to be a bit friendlier for developers. The `fetch*` and `include*` parameters cause response shapes to be polymorphic based on the combination of parameters, and the codegen isn't smart enough to tie specific combinations to `fetch*` / `include*` to specific codegenned types.

In practice, setting these parameters to `false` is almost never worth doing. Many fields in our API are eagerly resolved regardless of selection set, so options like `fetchShippingMethods` confer no performance benefit. At best developers save some negligible amount of network bandwidth, which doesn't seem like a compelling reason to include this API surface.

Codegen output looks like this now. The type is nice and flat:

![Screenshot 2025-04-10 at 13 02 04](https://github.com/user-attachments/assets/d18b4796-bae7-4c13-bcf8-fc75de053368)

There are some other small improvements included here:

1. `strictScalars: true` causes codegen to fail if `scalars` does not comprehensively map all custom scalars back to a TypeScript type. This prevents us from shipping an SDK where a scalar gets codegenned to `any` or `unknown`.
2. Don't re-export `graphql/gql.ts`. This file only contains internal types used to power typed document nodes, which are not useful to developers.
3. Drop deprecated `RyeClient` constructor signature. Removal of the `fetch*` / `include*` parameters is a breaking change in the first place, so may as well get this done.
4. Remove useless `IRyeClient` interface.

The types exported from our SDK are still not perfect. You can't write a function like this, for instance:

```typescript
import { Marketplace, ShopifyProduct } from '@rye-api/rye-sdk';

async function doSomethingWithAShopifyProduct(product: ShopifyProduct) {
  // ...
}

// ...

const product = await ryeClient.getProductById({
  input: { id: '...', marketplace: Marketplace.Shopify },
});
if (product?.__typename === 'ShopifyProduct') {
  await doSomethingWithAShopifyProduct(product); // <- type error
}
```

This is because the selection set in the body of the `productByID` operation does not comprehensively select all fields on `ShopifyProduct`. The _correct_ typing for `doSomethingWithAShopifyProduct`'s argument would be `Extract<ProductByIdQuery['productByID'], { __typename?: 'ShopifyProduct' }>`, which is extremely unwieldy.

We can fix this problem by either:

1. adding another codegen step which ensures all selection sets are comprehensive against our GraphQL schema or
2. manually curating re-exports rather than exporting everything from under `graphql/graphql.ts`

(1) is the better solution, but writing the script will require more time investment than I think is worth doing right now as overall usage of Rye SDK is fairly limited. Open to pushback on this, though.